### PR TITLE
make play speed controls more accessible

### DIFF
--- a/src/javascripts/app.coffee
+++ b/src/javascripts/app.coffee
@@ -167,6 +167,11 @@ class PodigeePodcastPlayer
       @player.changePlaySpeed()
       @updateSpeedDisplay()
 
+    @theme.speedSelectElement.change (event) =>
+      newSpeed = parseFloat(event.target.value)
+      @player.changePlaySpeed(newSpeed)
+      @updateSpeedDisplay()
+
   updateSpeedDisplay: () ->
     @theme.speedElement.text("#{@options.currentPlaybackRate}x")
 

--- a/src/javascripts/player.coffee
+++ b/src/javascripts/player.coffee
@@ -35,12 +35,14 @@ class Player
     @pause()
     @app.extensions.Playlist.playNext()
 
-  changePlaySpeed: () =>
-    nextRateIndex = @app.options.playbackRates.indexOf(@app.options.currentPlaybackRate) + 1
-    if nextRateIndex >= @app.options.playbackRates.length
-      nextRateIndex = 0
+  changePlaySpeed: (speed) =>
+    unless speed
+      nextRateIndex = @app.options.playbackRates.indexOf(@app.options.currentPlaybackRate) + 1
+      if nextRateIndex >= @app.options.playbackRates.length
+        nextRateIndex = 0
+      speed = @app.options.playbackRates[nextRateIndex]
 
-    @setPlaySpeed(@app.options.playbackRates[nextRateIndex])
+    @setPlaySpeed(speed)
 
   currentFile: =>
     @media.src
@@ -175,6 +177,7 @@ class Player
       @media.play().then(() => @setMediaSessionInfo()).catch((e) => console.debug(e))
     else
       @media.play()
+    @media.playbackRate = @app.options.currentPlaybackRate
     @playing = true
     @app.togglePlayState()
 

--- a/src/javascripts/theme.coffee
+++ b/src/javascripts/theme.coffee
@@ -138,6 +138,7 @@ class Theme
     @skipForwardElement = @elem.find('.skip-forward-button')
     @skipBackwardElement = @elem.find('.skip-backward-button')
     @speedElement = @elem.find('.speed-toggle')
+    @speedSelectElement = @elem.find('.speed-select')
     @coverImage = @elem.find('.cover-image')
     @subscribeButton = @elem.find('.subscribe-button')
 
@@ -165,6 +166,7 @@ class Theme
 
   initializeSpeedToggle: =>
     @speedElement.text('1x')
+    @speedSelectElement.val('1.0')
 
   changeActiveButton: (event) =>
     button = $(event.target)

--- a/src/themes/default/index.html
+++ b/src/themes/default/index.html
@@ -19,7 +19,16 @@
     <div class="controls-advanced">
       <button class="backward-button" pp-title="translations.backward" pp-aria-label="translations.backward"></button>
       <button class="forward-button" pp-title="translations.forward" pp-aria-label="translations.forward"></button>
-      <button class="speed-toggle" pp-title="translations.changePlaybackSpeed" pp-aria-label="translations.changePlaybackSpeed"></button>
+      <select class="speed-select" pp-title="translations.changePlaybackSpeed" pp-aria-label="translations.changePlaybackSpeed">
+        <option value="0.5">0.5x</option>
+        <option value="1.0">1x</option>
+        <option value="1.5">1.5x</option>
+        <option value="2.0">2.0x</option>
+        <option value="2.5">2.5x</option>
+        <option value="3.0">3.0x</option>
+        <option value="3.5">3.5x</option>
+        <option value="4.0">4.0x</option>
+      </select>
     </div>
 
     <div class="buttons"></div>

--- a/src/themes/default/index.scss
+++ b/src/themes/default/index.scss
@@ -97,11 +97,22 @@
       color: $highlight1;
     }
 
-    .speed-toggle {
-      cursor: pointer;
+    .speed-select {
+      -moz-appearance: none;
+      -webkit-appearance: none;
+      appearance: none;
+      border: 0;
+      background-color: $background-color;
+      background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22%23007CB2%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.5-3.5%205.4-7.8%205.4-12.8%200-5-1.9-9.2-5.5-12.8z%22%2F%3E%3C%2Fsvg%3E'), linear-gradient(to bottom, $background-color 0%, $background-color 100%);
+      color: $dark-grey;
       font-size: 14px;
+      outline: 0;
       position: relative;
       top: -3px;
+    }
+
+    .speed-select::-ms-expand {
+      display: none;
     }
   }
 


### PR DESCRIPTION
Switches the speed control UI element from a button to a select field as
this works much better for visually impared users.

Tested with Chrome, Safari, Firefox and IE 11+

![Screenshot 2020-01-16 at 10 56 12](https://user-images.githubusercontent.com/164417/72541334-50103500-3850-11ea-81e2-edd68c7f982d.png)
