### PR TITLE
Fix image size in episode descriptions

### DIFF
--- a/src/themes/default/index.scss
+++ b/src/themes/default/index.scss
@@ -61,6 +61,12 @@
     }
   }
 
+  .episode-info-open .episode-description {
+    img {
+      max-width: 100%;
+    }
+  }
+
   .cover-image {
     float: right;
     height: 90px;


### PR DESCRIPTION
Images could be wider than the size of the column.