### PR TITLE
Long titles in playlist can cause the duration to move into next line

### DIFF
--- a/src/themes/default/index.scss
+++ b/src/themes/default/index.scss
@@ -265,12 +265,14 @@
         li {
           background-color: none;
           cursor: pointer;
+          display: inline-block;
           line-height: 30px;
           list-style: none;
           padding: 0 25px 0 5px;
           position: relative;
+          width: 100%;
 
-          &+li {
+          & + li {
             border-top: 1px solid $light-grey;
           }
 

--- a/src/themes/default/index.scss
+++ b/src/themes/default/index.scss
@@ -1,7 +1,10 @@
 @import 'variables';
 
 .podcast-player {
-  &, *, *:before, *:after {
+  &,
+  *,
+  *:before,
+  *:after {
     -moz-box-sizing: border-box;
     -webkit-box-sizing: border-box;
     box-sizing: border-box;
@@ -179,11 +182,11 @@
       animation: move 2s linear infinite;
       background-image: linear-gradient(
         -45deg,
-        rgba(255, 255, 255, .2) 25%,
+        rgba(255, 255, 255, 0.2) 25%,
         transparent 25%,
         transparent 50%,
-        rgba(255, 255, 255, .2) 50%,
-        rgba(255, 255, 255, .2) 75%,
+        rgba(255, 255, 255, 0.2) 50%,
+        rgba(255, 255, 255, 0.2) 75%,
         transparent 75%,
         transparent
       );
@@ -192,10 +195,13 @@
       border-bottom-right-radius: 8px;
       border-top-left-radius: 20px;
       border-bottom-left-radius: 20px;
-      content: "";
+      content: '';
       overflow: hidden;
       position: absolute;
-      top: 0; left: 0; bottom: 0; right: 0;
+      top: 0;
+      left: 0;
+      bottom: 0;
+      right: 0;
     }
 
     @keyframes move {
@@ -305,9 +311,7 @@
             margin-left: 10px;
           }
 
-          .chaptermark-href
-
-          .episode-link,
+          .chaptermark-href .episode-link,
           .playlist-episode-number {
             display: none;
           }
@@ -446,7 +450,7 @@
       border-radius: 3px;
       font-size: 14px;
       font-weight: bold;
-      letter-spacing: .8px;
+      letter-spacing: 0.8px;
       outline: none;
       padding: 4px 6px;
     }
@@ -480,7 +484,7 @@
       float: right;
       font-size: 14px;
       font-weight: bold;
-      letter-spacing: .8px;
+      letter-spacing: 0.8px;
       padding: 6px 6px;
       text-decoration: none;
     }


### PR DESCRIPTION
If you have a very long episode title or a very small screen width, the duration can jump into the next line (for the next episode). This PR is providing a fix for it.