### PR TITLE
Include Credentials in GET Requests [Finishes #173966603]

### DIFF
--- a/src/javascripts/external_data.coffee
+++ b/src/javascripts/external_data.coffee
@@ -13,7 +13,12 @@ class ExternalData
     else
       url
 
-    $.get url, (params || {}), (data) -> deferred.resolve(data)
+    $.ajax
+      url: url
+      data: (params || {})
+      success: (data) -> deferred.resolve(data)
+      xhrFields:
+        withCredentials: true
 
     deferred.promise()
 


### PR DESCRIPTION
When fetching the transcript from a protected podcast the request needs
to include credentials in order to authenticate as an allowed listener.

The shortcut jQuery#get method does not allow to set the `xhrFields`
configuration, so the long form jQuery#ajax method is used.