### PR TITLE
Fix incorrectly displayed advanced controls when episode subtitle is missing [Finishes #174681832]

### DIFF
--- a/src/themes/default/index.scss
+++ b/src/themes/default/index.scss
@@ -58,6 +58,7 @@
     .episode-subtitle {
       color: $default-color;
       font-size: 16px;
+      min-height: 18px;
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
@@ -508,6 +509,7 @@
 
       .episode-subtitle {
         font-size: 14px;
+        min-height: 16px;
       }
     }
 

--- a/src/themes/legacy/index.scss
+++ b/src/themes/legacy/index.scss
@@ -99,6 +99,7 @@
 
     .episode-subtitle {
       font-size: 16px;
+      min-height: 18px;
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;


### PR DESCRIPTION
### **Description:**
When the subtitle of an episode is missing, then the advanced controls (backward, forward, speed) move up below the episode title, filling up the space that the subtitle would of occupied. Therefore the advanced controls are not in line with all other controls (time-played, download, episode-info, share, playlist) any more.

In the pivotal story there is a suggestion to use `&nbsp;` as content in case the subtitle is empty but in my opinion a better solution is to adjust weplayer css, and setting minimal height of the `div` which holds the episode subtitle.


### **Screenshots:**
Dekstop version:
- an episode with a subtitle for comparison
![controls_with_subtitle_compare](https://user-images.githubusercontent.com/20995317/92596709-89e1f000-f2a6-11ea-980a-c718a32bb9ec.png)

  - before:
![controls_desktop_before](https://user-images.githubusercontent.com/20995317/92596721-8e0e0d80-f2a6-11ea-9e10-57823ad17044.png)

  - after:
![controles_desktop_after](https://user-images.githubusercontent.com/20995317/92596731-90706780-f2a6-11ea-85eb-b55de0b2f128.png)


Mobile version:
- an episode with a subtitle for comparison
![controls_with_subtitle_compare_mobile](https://user-images.githubusercontent.com/20995317/92596741-936b5800-f2a6-11ea-84c2-8d1ffbe61bfa.png)

  - before:
![controls_mobile_before](https://user-images.githubusercontent.com/20995317/92596752-95cdb200-f2a6-11ea-8a80-11141add43c2.png)

  - after:
![controls_mobile_after](https://user-images.githubusercontent.com/20995317/92596762-99f9cf80-f2a6-11ea-89cf-c99b3a4b3773.png)


