### PR TITLE
Prevent generating IDs that start with a number

### DIFF
--- a/src/javascripts/embed.coffee
+++ b/src/javascripts/embed.coffee
@@ -1,5 +1,6 @@
 IframeResizer = require('./iframe_resizer.coffee')
 SubscribeButtonTrigger = require('./subscribe_button_trigger.coffee')
+_ = require('lodash')
 
 class Iframe
   constructor: (@elem)->
@@ -52,7 +53,10 @@ class Iframe
 
     hsh(string.charCodeAt(i)) for i in [0..string.length]
 
-    return hash.toString(16).substring(1)
+    potentialId = hash.toString(16).substring(1)
+    return potentialId if _.isNumber(potentialId.substring(0, 1))
+
+    "a#{potentialId.substring(1, potentialId.length)}"
 
   origin: () ->
     scriptSrc = @elem.src || @elem.getAttribute('src')


### PR DESCRIPTION
The current generation method for IDs that are attached to the iframe elements can potentially create IDs starting with a number. According to the HTML4 standard [1] this is not compliant and can be a problem for IE11 whose JS engine uses this standard in some cases.

This PR adjusts the generation of IDs by making sure that we are not generating IDs starting with a number. It's a rather simple logic and it justs replaces the first element of the ID with an "a" in that case. It could be improved more and pick e.g. a random letter from `[A-Za-z]`. But maybe it's good enough to use an "a" here, as it is assumed there won't be any other collisions with the random generated strings.

It feels also a little bit overkill to use `lodash` here instead of "building" an own check if the first character of the ID is a number, but as `lodash` is used anyway here...

[1] https://www.w3.org/TR/html4/types.html#type-name